### PR TITLE
Endpoints

### DIFF
--- a/Game/Game.js
+++ b/Game/Game.js
@@ -11,11 +11,19 @@ class Game {
     }
 
     setWordToGuess(word) {
-      this.wordToGuess = word.toLowerCase();
+      return this.wordToGuess = word.toLowerCase();
     }
 
     setGenerator(id) {
-      this.generatorID = id;
+      return this.generatorID = id;
+    }
+
+    getGuessesLeft() {
+      return this.maxWrongAttempts - this.wrongGuesses;
+    }
+
+    isOver() {
+      return this.maxWrongAttempts === this.wrongGuesses;
     }
 
     verifyGen(id) {
@@ -38,7 +46,7 @@ class Game {
 
     wrongAttempt(guess) {
         this.wrongGuesses += 1;
-        if (this.wrongGuesses >= this.maxWrongAttempts) {
+        if (this.isOver()) {
             return 'The man is dead';
         }
         return `'${guess}' was a bad guess.`

--- a/Game/Game.js
+++ b/Game/Game.js
@@ -1,13 +1,25 @@
+const symbols = '\ .,!?@#$%^&*()"\':;{}[]\\|<>/';
+
 class Game {
-    constructor(wordToGuess, maxWrongAttempts = 6) {
-        // this.alive = true;
-        this.player1;
-        this.player2;
-        this.wordToGuess = wordToGuess.toLowerCase();
+    constructor(maxWrongAttempts = 6) {
+        this.wordToGuess = '';
+        this.generatorID = null;
         this.maxWrongAttempts = maxWrongAttempts;
         this.attemptedGuesses = []; // All of these will be displayed as guesses
         this.wrongGuesses = 0;
         this.correctGuesses = []; // These will be displayed as correct guesses only
+    }
+
+    setWordToGuess(word) {
+      this.wordToGuess = word.toLowerCase();
+    }
+
+    setGenerator(id) {
+      this.generatorID = id;
+    }
+
+    verifyGen(id) {
+      return this.generatorID === id;
     }
 
     reviewAttempt(guess) {
@@ -37,7 +49,10 @@ class Game {
         if (this.correctGuesses.slice(-1)[0] == this.wordToGuess) {
             return this.winGame();
         }
-        if (theWordSplit.every(letter => this.correctGuesses.includes(letter))) {
+        let revealedAll = theWordSplit.every(letter => {
+            return this.correctGuesses.includes(letter) || symbols.includes(letter);
+        });
+        if (revealedAll) {
             return this.winGame();
         }
     }
@@ -50,7 +65,7 @@ class Game {
       let theWordSplit = this.wordToGuess.split('');
       return theWordSplit.map(letter => {
         if(this.correctGuesses.includes(letter) ||
-         '\ .,!?@#$%^&*()"\':;{}[]\\|<>/'.includes(letter)) {
+         symbols.includes(letter)) {
           return letter;
         }
         return '_';

--- a/server.js
+++ b/server.js
@@ -7,16 +7,16 @@ let game = new Game, players = [], generator;
 app.set('port', process.env.PORT || 3000);
 
 app.post('/', (req, resp) => {
-  if (req.act === 'join' && typeof(req.role) === 'boolean') {
-    joinGame(req.role, resp);
+  if (req.act === 'join') {
+    joinGame(req.isGenerator, resp);
   }
-  if (req.act === 'word' && req.word) {
+  if (req.act === 'word' && req.word &&) {
     startGame(req, resp)
   }
   if (req.act === 'guess') {
     makeGuess(req, resp)
   }
-  resp.status(400).json("Incorrect 'act' verb or supplementary options");
+  resp.status(400).json("Incorrect 'act' verb");
 })
 
 app.get('/', (req, resp) => {
@@ -24,6 +24,13 @@ app.get('/', (req, resp) => {
 })
 
 joinGame(isGenerator, resp) {
+  if (isGenerator === 'true') {
+    isGenerator = true;
+  } else if (isGenerator === 'false') {
+    isGenerator = false;
+  } else {
+    return resp.status(400).json(`Role needs to be \`true\` or \`false\`. Is: ${resp.isGenerator}.`);
+  }
   let id = Date.now();
   while (players.includes(id)) {
     id -= 1;
@@ -35,7 +42,16 @@ joinGame(isGenerator, resp) {
   resp.status(200).json(id);
 }
 
-startGame()
+startGame({ word, id }, resp) {
+  if (!word || !id) {
+    return resp.status(400).json(`Word or id are missing. Word: ${word}. Id: ${id}`);
+  }
+  game.setWordToGuess(word);
+  if (players.length < 2) {
+    return resp.status(200).json(`Received. Waiting on others to join...`);
+  }
+  resp.status(200).json('Received. Game starting.')
+}
 
 
 

--- a/server.js
+++ b/server.js
@@ -2,9 +2,47 @@ const app = require('express')();
 const server = require('http').createServer(app);
 const io = require('socket.io')(server);
 const Game = require('./Game/Game.js');
-let game;
+let game = new Game, players = [], generator;
 
 app.set('port', process.env.PORT || 3000);
+
+app.post('/', (req, resp) => {
+  if (req.act === 'join' && typeof(req.role) === 'boolean') {
+    joinGame(req.role, resp);
+  }
+  if (req.act === 'word' && req.word) {
+    startGame(req, resp)
+  }
+  if (req.act === 'guess') {
+    makeGuess(req, resp)
+  }
+  resp.status(400).json("Incorrect 'act' verb or supplementary options");
+})
+
+app.get('/', (req, resp) => {
+  resp.send('<h3>Connected</h3>');
+})
+
+joinGame(isGenerator, resp) {
+  let id = Date.now();
+  while (players.includes(id)) {
+    id -= 1;
+  }
+  if (isGenerator) {
+    game.setGenerator(id);
+  }
+  players.push(id);
+  resp.status(200).json(id);
+}
+
+startGame()
+
+
+
+server.listen(app.get('port'), () => {
+  console.log(`Listening on port ${app.get('port')}.`);
+});
+
 
 io.on('connection', (socket) => {
   console.log('A user has connected.', io.engine.clientsCount)
@@ -14,26 +52,5 @@ io.on('connection', (socket) => {
     io.sockets.emit(`User${io.engine.clientsCount} has disconnected`);
   })
 })
-
-app.post('/', (req, resp) => {
-  if (req.act === 'join') {
-    joinGame(resp);
-  }
-  if (req.act === 'word') {
-    startGame(req, resp)
-  }
-  if (req.act === 'guess') {
-    makeGuess(req, resp)
-  }
-  resp.status(400).json("Incorrect 'act' verb");
-})
-
-app.get('/', (req, resp) => {
-  resp.send('<h3>Connected</h3>');
-})
-
-server.listen(app.get('port'), () => {
-  console.log(`Listening on port ${app.get('port')}.`);
-});
 
 module.exports = server;

--- a/server.js
+++ b/server.js
@@ -1,6 +1,8 @@
 const app = require('express')();
 const server = require('http').createServer(app);
 const io = require('socket.io')(server);
+const Game = require('./Game/Game.js');
+let game;
 
 app.set('port', process.env.PORT || 3000);
 
@@ -11,6 +13,19 @@ io.on('connection', (socket) => {
     console.log('A user has disconnected.', io.engine.clientsCount)
     io.sockets.emit(`User${io.engine.clientsCount} has disconnected`);
   })
+})
+
+app.post('/', (req, resp) => {
+  if (req.act === 'join') {
+    joinGame(resp);
+  }
+  if (req.act === 'word') {
+    startGame(req, resp)
+  }
+  if (req.act === 'guess') {
+    makeGuess(req, resp)
+  }
+  resp.status(400).json("Incorrect 'act' verb");
 })
 
 app.get('/', (req, resp) => {

--- a/server.js
+++ b/server.js
@@ -1,29 +1,32 @@
-const app = require('express')();
+const express = require('express');
+const app = express();
 const server = require('http').createServer(app);
 const io = require('socket.io')(server);
 const Game = require('./Game/Game.js');
 let game = new Game, players = [], generator;
 
+app.use(express.json());
 app.set('port', process.env.PORT || 3000);
 
-app.post('/', (req, resp) => {
-  if (req.act === 'join') {
-    joinGame(req.isGenerator, resp);
+app.post('/', ({ body }, resp) => {
+  console.log(body)
+  if (body.act === 'join') {
+    joinGame(body.isGenerator, resp);
   }
-  if (req.act === 'word' && req.word &&) {
-    startGame(req, resp)
+  if (body.act === 'word') {
+    startGame(body, resp)
   }
-  if (req.act === 'guess') {
-    makeGuess(req, resp)
+  if (body.act === 'guess') {
+    makeGuess(body, resp)
   }
-  resp.status(400).json("Incorrect 'act' verb");
+  resp.status(400).json(`Incorrect 'act' verb, Received: ${body.act}`);
 })
 
-app.get('/', (req, resp) => {
+app.get('/', (body, resp) => {
   resp.send('<h3>Connected</h3>');
 })
 
-joinGame(isGenerator, resp) {
+function joinGame(isGenerator, resp) {
   if (isGenerator === 'true') {
     isGenerator = true;
   } else if (isGenerator === 'false') {
@@ -46,8 +49,8 @@ joinGame(isGenerator, resp) {
   );
 }
 
-startGame({ word, id }, resp) {
-  if (!word || !id) {
+function startGame({ word, id }, resp) {
+  if (!word) {
     return resp.status(400).json(`Word is missing. Word: ${word}.`);
   }
   if (game.verifyGen(id)) {
@@ -64,7 +67,7 @@ startGame({ word, id }, resp) {
   });
 }
 
-makeGuess({ guess, id }) {
+function makeGuess({ guess, id }, resp) {
   if (!guess) {
     return resp.status(400).json(`Guess is missing. Guess: ${guess}.`);
   }


### PR DESCRIPTION
# Description

Added a post endpoint to the server to start and run the game.
It branches into 3 different helper functions:

 - `startGame` (should maybe rename to setWord) takes a word to guess and sets it in the game
 - `joinGame` allows players to join, as well as to designate if they should generate the word (at the moment, there are no safeguards in place, so a person may overwrite and 'steal' the generator role)
- `makeGuess` allows players to guess letters and words. Updates the game, and return display information.

There are some preliminary safeguards and error handling hooks set up, but we can flesh those out later.

# How was this tested

In POSTMAN. Can demo over slack call later.

# Thoughts
Still need to write endpoints that let players leave, but I think that will be better to do with `socket.on('disconnect')` which will be utilized later.

So far this can interact with the page without sockets, but it will be MUCH more responsive and better with `sockets`. I think next step is to hook that up.