### PR TITLE
Add socket.io to production dependencies from dev dep.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "jest": "^26.6.1",
     "mocha": "^7.1.2",
     "mocha-jsdom": "^2.0.0",
-    "socket.io": "^2.3.0",
     "supertest": "^6.0.0"
   },
   "repository": {
@@ -42,6 +41,7 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.17.1",
+    "socket.io": "^2.3.0",
     "lodash": "^4.17.20"
   }
 }


### PR DESCRIPTION
# Description

Needed `socket.io` to be a regular dependency for production.
