### PR TITLE
Add tests for each socket event.

### DIFF
--- a/server.js
+++ b/server.js
@@ -17,13 +17,13 @@ io.on( "connect", ( socket ) => {
       game.setGenerator(socket.id);
     }
     players.push(socket.id);
-    io.emit('gameJoined', getStateData())
+    io.emit('result', getStateData())
   })
 
   socket.on( 'setWord', ( word ) => {
     game.reset();
     game.setWordToGuess(word);
-    io.emit('newWordToGuess', getStateData())
+    io.emit('result', getStateData())
   })
 
   socket.on( 'makeGuess', ( guess ) => {
@@ -43,104 +43,11 @@ function isGameReady() {
 function getStateData() {
   return {
     display: game.displayRevealed(),
-    guesses: game.attemptedGuesses,
     isOver: game.isOver(),
     remainingGuesses: game.getGuessesLeft(),
-    isOver: game.isOver(),
     attempts: game.attemptedGuesses,
     isGameReady: isGameReady()
   }
-}
-
-app.post('/', ({ body }, resp) => {
-  if (body.act === 'join') {
-    joinGame(body.isGenerator, resp);
-  }
-  if (body.act === 'word') {
-    setWord(body, resp)
-  }
-  if (body.act === 'guess') {
-    makeGuess(body, resp)
-  }
-  if (body.act === 'clear') {
-    clearGame(resp)
-  }
-  resp.status(400).json(`Incorrect 'act' verb, Received: ${body.act}`);
-})
-
-app.get('/', (body, resp) => {
-  resp.status(200).json({
-    numPlayers: players.length,
-    attempts: game.attemptedGuesses,
-    remainingGuesses: game.getGuessesLeft(),
-    isOver: game.isOver(),
-    display: game.displayRevealed(),
-    ready: players.length >= 2 && game.generatorID !== null && game.wordToGuess !== ''
-  });
-})
-
-function joinGame(isGenerator, resp) {
-  if (isGenerator === 'true') {
-    isGenerator = true;
-  } else if (isGenerator === 'false') {
-    isGenerator = false;
-  } else {
-    return resp.status(400).json(`Role needs to be \`true\` or \`false\`. Is: ${resp.isGenerator}.`);
-  }
-  let id = Date.now();
-  while (players.includes(id)) {
-    id -= 1;
-  }
-  if (isGenerator) {
-    game.setGenerator(id);
-  }
-  players.push(id);
-  resp.status(200).json({
-    id,
-    ready: players.length >= 2 && game.generatorID !== null && game.wordToGuess !== '',
-    isGenerator: isGenerator,
-    numPlayers: players.length
-  });
-}
-
-function setWord({ word, id }, resp) {
-  if (!word) {
-    return resp.status(400).json(`Word is missing. Word: ${word}.`);
-  }
-  if (!game.verifyGen(id)) {
-    return resp.status(401).json(`Not the generator. ID provided: ${id}.`);
-  }
-  game.setWordToGuess(word);
-  if (players.length < 2) {
-    return resp.status(200).json(`Received. Waiting on others to join...`);
-  }
-  resp.status(200).json(
-    {
-      display: game.displayRevealed(),
-      remainingGuesses: game.getGuessesLeft(),
-      isOver: game.isOver(),
-      attempts: game.attemptedGuesses
-    }
-  );
-}
-
-function makeGuess({ guess, id }, resp) {
-  if (guess.length <= 0) {
-    return resp.status(400).json(`Guess is missing. Guess: ${guess}.`);
-  }
-  if (game.verifyGen(id)) {
-    return resp.status(401).json(`Generator is not allowed to guess. ID provided: ${id}.`);
-  }
-  if (!players.includes(+id)) {
-    return resp.status(401).json(`Only current players may guess. ID provided: ${id}.`);
-  }
-  game.reviewAttempt(guess);
-  resp.status(200).json({
-    display: game.displayRevealed(),
-    remainingGuesses: game.getGuessesLeft(),
-    isOver: game.isOver(),
-    attempts: game.attemptedGuesses
-  })
 }
 
 function clearGame(resp) {

--- a/server.test.js
+++ b/server.test.js
@@ -3,196 +3,91 @@ let { server, game } = require('./server.js');
 let request = require('supertest');
 let Game = require('./Game/Game.js');
 
-  // let socket, app;
-  // beforeEach(function(done) {
-  //   socket = io.connect('http://localhost:3000', {
-  //     'reconnection delay' : 0
-  //     , 'reopen delay' : 0
-  //     , 'force new connection' : true
-  //   });
-  //   socket.on('connect', function() {
-  //     console.log('worked...');
-  //     done();
-  //   });
-  //   socket.on('disconnect', function() {
-  //     console.log('disconnected...');
-  //   })
-  // });
-  //
-  // afterEach(function(done) {
-  //       // Cleanup
-  //   if(socket.connected) {
-  //     console.log('disconnecting...');
-  //     socket.disconnect();
-  //   } else {
-  //   // There will not be a connection unless you have done() in beforeEach, socket.on('connect'...)
-  //     console.log('no connection to break...');
-  //   }
-  //   done();
-  // });
+let socket, app, socketIsLoaded, callCount, result;
 
-let guesserID, genID;
+function mockSetState(data, done) {
+  callCount++;
+  result = data;
+  done();
+}
 
 describe('server', function() {
 
-  it('should return a connected message by default', async function(done) {
-    const res = await request(server)
-                      .get('/');
-    expect(res.statusCode).toEqual(200);
-    expect(res.body).toEqual('<h3>Connected</h3>');
+  beforeAll( (done) => {
+    socket = io.connect('http://localhost:3001', {
+      'reconnection delay' : 0
+      , 'reopen delay' : 0
+      , 'force new connection' : true
+    });
 
+    socket.on('connect', function() {
+      socketIsLoaded = true;
+      done();
+    });
+
+    socket.on('result', (data) => mockSetState(data, done) );
+  });
+
+  it('should connect on load', async (done) => {
+    expect(socketIsLoaded).toEqual(true)
     done();
   });
 
-  describe('joinGame', function() {
-
-    it('should be able to host a new game', async function(done) {
-      const res = await request(server)
-                        .post('/')
-                        .send({
-                          "act": "join",
-                          "isGenerator": "false"
-                        });
-
-      guesserID = res.body.id;
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.ready).toEqual(false);
-      expect(res.body.isGenerator).toEqual(false);
-      expect(res.body.numPlayers).toEqual(1);
-      expect(game.generatorID).toBeNull();
-      done();
-    });
-
-    it('when the second player joins, the game should be ready', async function(done) {
-      const res = await request(server)
-                        .post('/')
-                        .send({
-                          "act": "join",
-                          "isGenerator": "true"
-                        });
-      genID = res.body.id;
-      expect(res.body.ready).toEqual(true);
-      expect(res.body.isGenerator).toEqual(true);
-      expect(res.body.numPlayers).toEqual(2);
-      expect(game.generatorID).toBeTruthy();
-      done();
-    });
-
-    it('should return bad response when malformed requests are given', async function(done) {
-      const badGen = await request(server)
-                        .post('/')
-                        .send({
-                          "act": "join",
-                          "isGenerator": ""
-                        });
-      expect(badGen.statusCode).toEqual(400);
-      done();
-    });
-  });
-
-  describe('setWordToGuess', function() {
-
-    it('should be able to set new word', async function(done) {
-      const res = await request(server)
-                        .post('/')
-                        .send({
-                          "act": "word",
-                          "word": "debug",
-                          "id": JSON.stringify(genID)
-                        });
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.display).toEqual(['_','_','_','_','_']);
-      expect(res.body.guesses).toEqual(6);
-      expect(res.body.isOver).toEqual(false);
-      expect(game.wordToGuess).toEqual('debug');
-      done();
-    });
-
-    it('should return an error for malformed bodies', async function(done) {
-      const badWord = await request(server)
-                        .post('/')
-                        .send({
-                          "act": "word",
-                          "word": "",
-                          "id": JSON.stringify(guesserID)
-                        });
-      expect(badWord.statusCode).toEqual(400);
-
-      const badid = await request(server)
-                        .post('/')
-                        .send({
-                          "act": "word",
-                          "word": "asd",
-                          "id": JSON.stringify(guesserID)
-                        });
-      expect(badid.statusCode).toEqual(401);
-      expect(game.wordToGuess).toEqual('debug');
-      done();
-    });
-  });
-
-  describe('makeGuess', function() {
-
-    it('should be able to guess letters', async function(done) {
-      const res = await request(server)
-                        .post('/')
-                        .send({
-                          "act": "guess",
-                          "guess": "d",
-                          "id": JSON.stringify(guesserID)
-                        });
-      expect(res.statusCode).toEqual(200);
-      expect(res.body.display).toEqual(['d','_','_','_','_']);
-      expect(res.body.guesses).toEqual(6);
-      expect(res.body.isOver).toEqual(false);
-      expect(game.wordToGuess).toEqual('debug');
-      done();
-    });
-
-    it('should return an error for malformed bodies', async function(done) {
-      const badWord = await request(server)
-                        .post('/')
-                        .send({
-                          "act": "guess",
-                          "guess": "",
-                          "id": JSON.stringify(guesserID)
-                        });
-      expect(badWord.statusCode).toEqual(400);
-
-      const badid = await request(server)
-                        .post('/')
-                        .send({
-                          "act": "guess",
-                          "guess": "a",
-                          "id": JSON.stringify(genID)
-                        });
-      expect(badid.statusCode).toEqual(401);
-      expect(game.wordToGuess).toEqual('debug');
-      done();
-    });
-  });
-
-  describe('clear', function() {
-
-    it('should be able to reset the game', async function(done) {
-      const res = await request(server)
-                        .post('/')
-                        .send({
-                          "act": "clear"
-                        });
-      expect(res.statusCode).toEqual(200);
-      expect(res.body).toEqual({
-        numPlayers: 0,
-        isGenerator: null,
-        guesses: [],
+  it('should be able to join a game', async (done) => {
+    callCount = 0;
+    socket.emit('joinGame', true);
+    setTimeout(() => {
+      expect(callCount).toEqual(1);
+      expect(result).toEqual({
+        display: [],
         isOver: false,
-        display: []
-      });
+        remainingGuesses: 6,
+        attempts: [],
+        isGameReady: false
+      })
       done();
-    });
+    }, 50)
   });
 
-  afterAll(function(done) {
+  it('should be able to set a word', async (done) => {
+    callCount = 0;
+    socket.emit('setWord', 'debug');
+    setTimeout(() => {
+      expect(callCount).toEqual(1);
+      expect(result).toEqual({
+        display: ['_', '_', '_', '_', '_'],
+        isOver: false,
+        remainingGuesses: 6,
+        attempts: [],
+        isGameReady: false
+      })
+      done();
+    }, 80)
+  });
+
+  it('should be able to make a guess', async (done) => {
+    callCount = 0;
+    socket.emit('makeGuess', 'd');
+    socket.emit('makeGuess', 'x')
+    setTimeout(() => {
+      expect(callCount).toEqual(2);
+      expect(result).toEqual({
+        display: ['d', '_', '_', '_', '_'],
+        isOver: false,
+        remainingGuesses: 5,
+        attempts: ['d', 'x'],
+        isGameReady: false
+      })
+      done();
+    }, 80)
+  });
+
+  afterAll( (done) => {
+    if(socket.connected) {
+      socketIsLoaded = false;
+      socket.disconnect();
+    }
     server.close(done)
+    done();
   });
 });


### PR DESCRIPTION
# Description

Added tests for each current socket event, namely: 
  
  - `joinGame`
  - `setWord`
  - `makeGuess`

I also realized that each of them were always returning the same data, so instead of returning unique events, I made them all use the same event named `result`. The client-side will need to be updated to mirror this.

# snapshot of tests

<img width="719" alt="Screen Shot 2020-10-31 at 4 40 42 PM" src="https://user-images.githubusercontent.com/65369751/97792165-d60b2b80-1b97-11eb-94c7-fc1577f4e731.png">

# Linked issues

[Issue #54](https://github.com/GreyMatteOr/bangwords/issues/54)

# Notes

In the process of writing these tests, I also cleaned up / deleted a lot of the unused fetch / endpoint code in the server. Some is still left as a visible reminder, though


